### PR TITLE
update sprite for Marksman headpiece

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -262,7 +262,7 @@
     },
     {
       "id": 52,
-      "itemID": 2982,
+      "itemID": 2983,
       "description": "Get the Marksman headpiece"
     },
     {


### PR DESCRIPTION
used the blue hat sprite (95kc), should use the yellow one now. Granted, item ID lists didnt load the images so had to assume that the 2983 ID was the next one in list (Which it very much should)